### PR TITLE
Move to supported docker-compose syntax

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,17 +72,17 @@ jobs:
             Example docker-compose.yaml:
 
             ```
-            version: "3.8"
+            name: subsyncarr
 
             services:
-            subsyncarr:
-              image: mrorbitman/subsyncarr:latest
-              container_name: subsyncarr
-              volumes:
-              - ${MEDIA_PATH:-/path/to/your/media}:/scan_dir
-              restart: unless-stopped
-              environment:
-              - TZ=${TZ:-UTC}
+              subsyncarr:
+                image: mrorbitman/subsyncarr:latest
+                container_name: subsyncarr
+                volumes:
+                  - ${MEDIA_PATH:-/path/to/your/media}:/scan_dir
+                restart: unless-stopped
+                environment:
+                  - TZ=${TZ:-UTC}
             ```
 
             Docker Hub URL: https://hub.docker.com/r/mrorbitman/subsyncarr/tags

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: subsyncarr
 
 services:
   subsyncarr:


### PR DESCRIPTION
The `version:` directive has been deprecated for quite some time, and has been replaced with the `name:` invocation.

https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313

https://docs.docker.com/reference/compose-file/version-and-name/