### PR TITLE
feat: remove .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An automated subtitle synchronization tool that runs as a Docker container. It w
 mkdir subsyncarr && cd subsyncarr
 ```
 
-#### 2. Download the docker-compose.yml and .env.example files:
+#### 2. Download the docker-compose.yml file:
 
 ```bash
 curl -O https://raw.githubusercontent.com/johnpc/subsyncarr/main/docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -25,23 +25,15 @@ mkdir subsyncarr && cd subsyncarr
 
 ```bash
 curl -O https://raw.githubusercontent.com/johnpc/subsyncarr/main/docker-compose.yml
-curl -O https://raw.githubusercontent.com/johnpc/subsyncarr/main/.env.example
 ```
 
-#### 3. Create your .env file:
+#### 3. Edit the docker-compose.yml file with your timezone and paths:
 
 ```bash
-cp .env.example .env
-```
-
-#### 4. Edit the .env file with your settings:
-
-```bash
-MEDIA_PATH=/path/to/your/media
 TZ=America/New_York  # Adjust to your timezone
 ```
 
-#### 5. Start the container:
+#### 4. Start the container:
 
 ```bash
 docker-compose up -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,13 +7,13 @@ services:
     volumes:
       # Any path configured with SCAN_PATHS env var must be mounted
       # If no scan paths are specified, it defaults to scan `/scan_dir` like example below.
-      # - ${MEDIA_PATH:-/path/to/your/media}:/scan_dir
+      # - /path/to/your/media:/scan_dir
       - /path/to/movies:/movies
       - /path/to/tv:/tv
       - /path/to/anime:/anime
     restart: unless-stopped
     environment:
-      - TZ=${TZ:-UTC}
+      - TZ=Etc/UTC # Replace with your own timezone
       - CRON_SCHEDULE=0 0 * * * # Runs every day at midnight by default
       - SCAN_PATHS=/movies,/tv,/anime # Remember to mount these as volumes. Must begin with /. Default valus is `/scan_dir`
       - EXCLUDE_PATHS=/movies/temp,/tv/downloads # Exclude certain sub-directories from the scan

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,6 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Etc/UTC # Replace with your own timezone
-      - CRON_SCHEDULE=0 0 * * * # Runs every day at midnight by default
+      - CRON_SCHEDULE='0 0 * * *' # Runs every day at midnight by default
       - SCAN_PATHS=/movies,/tv,/anime # Remember to mount these as volumes. Must begin with /. Default valus is `/scan_dir`
       - EXCLUDE_PATHS=/movies/temp,/tv/downloads # Exclude certain sub-directories from the scan


### PR DESCRIPTION
With the changes to scanning, I am not sure if the .env file is needed anymore. I would propose to simplify the deployment to a single docker-compose.yml