### PR TITLE
switch to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ TZ=America/New_York  # Adjust to your timezone
 #### 4. Start the container:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Configuration


### PR DESCRIPTION
https://docs.docker.com/compose/releases/migrate/

I should have included this in the last PR, sorry!

`docker-compose` is deprecated along with `version:`, the new syntax is `docker compose up -d`

Filename syntax is unchanged