### PR TITLE
feat: enable non-root container behavior for user 1000:1000

### DIFF
--- a/src/findAllSrtFiles.ts
+++ b/src/findAllSrtFiles.ts
@@ -22,6 +22,7 @@ export async function findAllSrtFiles(config: ScanConfig): Promise<string[]> {
         entry.isFile() &&
         extname(entry.name).toLowerCase() === '.srt' &&
         !entry.name.includes('.ffsubsync.') &&
+        !entry.name.includes('.alass.') &&
         !entry.name.includes('.autosubsync.')
       ) {
         files.push(fullPath);


### PR DESCRIPTION
See https://github.com/johnpc/subsyncarr/issues/1

I'm pretty sure this works, I tested it with 

```
docker run -d \
  --name subtitle-sync \
  -v $HOME/repo/syncarr:/scan_dir \
    --user "1000:1000" \
app
```

However, it _only_ works with 1000:1000 as the user. Other ids still cause permissions errors. I will look into it more later if there is demand for it. For now it seems 1000:1000 is what we want.

I also tested that there are no regressions with the current behavior.

