### PR TITLE
feat: add SYNC_TIMEOUT env var and document all parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ docker compose up -d
 
 ## Configuration
 
-The container is configured to:
+### Environment Variables
 
-- Scan for subtitle files in the mounted directory
-- Run synchronization at container startup
-- Run daily at midnight (configurable via cron)
-- Generate synchronized subtitle versions using different tools (currently ffsubsync and autosubsync)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SCAN_PATHS` | `/scan_dir` | Comma-separated list of directories to scan |
+| `EXCLUDE_PATHS` | _(none)_ | Comma-separated list of directories to exclude |
+| `INCLUDE_ENGINES` | `ffsubsync,autosubsync,alass` | Comma-separated list of sync engines to use |
+| `MAX_CONCURRENT_SYNC_TASKS` | `1` | Number of files to process in parallel |
+| `SYNC_TIMEOUT` | _(none)_ | Timeout in seconds per sync operation. If a sync engine hangs, it will be killed and skipped after this duration. |
 
 ### Directory Structure
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,3 @@
-import { promisify } from 'util';
 import { exec } from 'child_process';
 
 export interface ProcessingResult {
@@ -6,4 +5,28 @@ export interface ProcessingResult {
   message: string;
 }
 
-export const execPromise = promisify(exec);
+const DEFAULT_TIMEOUT_MS = 0; // 0 = no timeout
+
+function getTimeoutMs(): number {
+  const val = process.env.SYNC_TIMEOUT;
+  if (!val) return DEFAULT_TIMEOUT_MS;
+  const seconds = parseInt(val, 10);
+  return isNaN(seconds) || seconds <= 0 ? DEFAULT_TIMEOUT_MS : seconds * 1000;
+}
+
+export function execPromise(command: string): Promise<{ stdout: string; stderr: string }> {
+  const timeoutMs = getTimeoutMs();
+  return new Promise((resolve, reject) => {
+    const child = exec(command, { timeout: timeoutMs }, (error, stdout, stderr) => {
+      if (error) {
+        if (error.killed) {
+          reject(new Error(`Timed out after ${timeoutMs / 1000}s: ${command}`));
+        } else {
+          reject(error);
+        }
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+}


### PR DESCRIPTION
Adds a configurable `SYNC_TIMEOUT` environment variable (in seconds) for sync engine operations. If ffsubsync, alass, or autosubsync hangs, the process is killed and skipped after the specified duration.

Also adds a parameters table to the README documenting all environment variables.

Example usage:
```yaml
environment:
  SYNC_TIMEOUT: 300  # kill any sync that takes longer than 5 minutes
```

Closes #30
Relates to #29