### PR TITLE
fix: add runtime PUID/PGID support for file permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
 # Use Node.js LTS (Long Term Support) as base image
 FROM node:20-bullseye
 
-# Create app user and group with configurable UID/GID
+# Default PUID/PGID - can be overridden at runtime
 ENV PUID=1000
 ENV PGID=1000
 
-RUN mkdir -p /app
-RUN chown node:node /app
+RUN mkdir -p /app && chown node:node /app
 
-# Modify existing node user instead of creating new one
-RUN groupmod -g ${PGID} node && \
-    usermod -u ${PUID} -g ${PGID} node && \
-    chown -R node:node /home/node
-RUN apt-get clean
-
-# Install system dependencies including ffmpeg, Python, and cron
+# Install system dependencies including ffmpeg, Python, cron, and gosu
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     python3 \
     python3-pip \
     python3-venv \
     cron \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER node
 # Set working directory
@@ -75,4 +73,7 @@ tail -f /app/logs/app.log' > /app/startup.sh
 RUN chmod +x /app/startup.sh
 
 # Use startup script as entrypoint
+# Switch to root so entrypoint can adjust PUID/PGID, then drops to node via gosu
+USER root
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/app/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ docker compose up -d
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `PUID` | `1000` | User ID for file ownership. Run `id -u` to find yours. |
+| `PGID` | `1000` | Group ID for file ownership. Run `id -g` to find yours. |
 | `SCAN_PATHS` | `/scan_dir` | Comma-separated list of directories to scan |
 | `EXCLUDE_PATHS` | _(none)_ | Comma-separated list of directories to exclude |
 | `INCLUDE_ENGINES` | `ffsubsync,autosubsync,alass` | Comma-separated list of sync engines to use |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - /path/to/anime:/anime
     restart: unless-stopped
     environment:
+      - PUID=1000 # Set to your user's UID (run `id -u` to find it)
+      - PGID=1000 # Set to your user's GID (run `id -g` to find it)
       - TZ=Etc/UTC # Replace with your own timezone
       - CRON_SCHEDULE=0 0 * * * # Runs every day at midnight by default
       - SCAN_PATHS=/movies,/tv,/anime # Remember to mount these as volumes. Must begin with /. Default valus is `/scan_dir`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Adjust node user UID/GID at runtime if PUID/PGID are set
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+if [ "$(id -u node)" != "$PUID" ] || [ "$(id -g node)" != "$PGID" ]; then
+  groupmod -o -g "$PGID" node
+  usermod -o -u "$PUID" node
+  chown -R node:node /app /home/node
+fi
+
+exec gosu node "$@"


### PR DESCRIPTION
Adds an entrypoint script that adjusts the node user's UID/GID at container startup based on `PUID`/`PGID` environment variables. This fixes issues where synced subtitle files aren't written due to permission mismatches on mounted volumes (common on Synology NAS).

Previously PUID/PGID were set at build time which had no effect when users passed them at runtime.

Usage:
```yaml
environment:
  - PUID=1000  # run `id -u` to find yours
  - PGID=1000  # run `id -g` to find yours
```

Closes #22