### PR TITLE
fix: inject setuptools into ffsubsync venv for pkg_resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN npm run build
 USER node
 ENV PATH="/home/node/.local/bin:$PATH"
 RUN pipx install ffsubsync \
+    && pipx inject ffsubsync 'setuptools<82' \
     && pipx install autosubsync \
     && find /home/node/.local/share/pipx -type f -name "*.pyc" -delete 2>/dev/null || true \
     && find /home/node/.local/share/pipx -type d -name "__pycache__" -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary
Fixes #40 — `ModuleNotFoundError: No module named 'pkg_resources'` when ffsubsync tries to use webrtcvad.

## Root Cause
`webrtcvad` (a dependency of ffsubsync) does `import pkg_resources` at the top level. `pkg_resources` comes from `setuptools`, but:
1. It's not installed in ffsubsync's isolated pipx venv by default
2. setuptools 82.0+ removed `pkg_resources` entirely

## Fix
Added `pipx inject ffsubsync 'setuptools<82'` to the Dockerfile build stage. This installs setuptools (with pkg_resources) directly into ffsubsync's pipx venv, which gets copied to the runtime stage.

## Tested
- Built image on aarch64
- Verified `import pkg_resources` succeeds in the ffsubsync venv
- Verified `import webrtcvad` succeeds
- Verified `ffsubsync --help` runs cleanly