### PR TITLE
fix: remove user directive from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ services:
   subsyncarr:
     image: mrorbitman/subsyncarr:latest
     container_name: subsyncarr
-    user: '1000:10'
     ports:
       - '3000:3000' # Web UI
     volumes:
@@ -81,7 +80,6 @@ Open your browser to [http://localhost:3000](http://localhost:3000) or whatever 
 ```bash
 docker run -d \
   --name subsyncarr \
-  --user 1000:10 \
   -p 3000:3000 \
   -v /path/to/movies:/movies \
   -v /path/to/tv:/tv \
@@ -259,6 +257,8 @@ id -g  # Get your group ID
 ```
 
 Then update your docker-compose.yaml with these values.
+
+> **Note:** Do not use the `user:` directive in docker-compose or `--user` in docker run. The container must start as root so the entrypoint can configure file permissions using `PUID`/`PGID`, then drops to the unprivileged user automatically via `gosu`.
 
 ### Memory Issues
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   subsyncarr:
     image: mrorbitman/subsyncarr:latest
     container_name: subsyncarr
-    user: "1000:10"
     ports:
       - '3000:3000' # Web UI
     volumes:
@@ -26,8 +25,6 @@ services:
       - PUID=1000 # Set to your user's UID (run `id -u` to find it)
       - PGID=1000 # Set to your user's GID (run `id -g` to find it)
       - TZ=Etc/UTC # Replace with your own timezone
-      - PUID=1000
-      - PGID=10
       - CRON_SCHEDULE=0 0 * * * # Runs every day at midnight by default
       - SCAN_PATHS=/movies,/tv # Remember to mount these as volumes. Must begin with /. Default valus is `/scan_dir`
       - EXCLUDE_PATHS=/movies/temp,/tv/downloads # Exclude certain sub-directories from the scan


### PR DESCRIPTION
Fixes #52

## Summary
The `entrypoint.sh` uses `groupmod`, `usermod`, `chown`, and `gosu` which all require root. The container must start as root so the entrypoint can configure permissions, then it drops to the unprivileged user via `gosu node`.

The `user: '1000:10'` directive in docker-compose (and `--user` in docker run) overrides the Dockerfile's `USER root`, preventing the entrypoint from functioning.

## Changes
- Removed `user: '1000:10'` from README docker-compose example
- Removed `--user 1000:10` from README docker run example
- Added note in Troubleshooting explaining why `user:` should not be used
- Removed `user: "1000:10"` from `docker-compose.yaml`
- Fixed duplicate PUID/PGID entries in `docker-compose.yaml`