### PR TITLE
fix: show skipped count when all files already synced

### DIFF
--- a/src/coordinator.ts
+++ b/src/coordinator.ts
@@ -29,8 +29,8 @@ export class ProcessingCoordinator {
       }
     });
 
-    this.engine.on('run:files_found', (files: string[]) => {
-      this.currentRunId = this.stateManager.startRun(files.length, this.enabledEngines);
+    this.engine.on('run:files_found', (files: string[], skippedCount: number) => {
+      this.currentRunId = this.stateManager.startRun(files.length, this.enabledEngines, skippedCount);
 
       // Add all files to database as pending (video matching happens during processing)
       for (const filePath of files) {

--- a/src/findAllSrtFiles.ts
+++ b/src/findAllSrtFiles.ts
@@ -13,7 +13,12 @@ function isAlreadySynced(srtPath: string, engines: string[]): boolean {
   });
 }
 
-export async function findAllSrtFiles(config: ScanConfig): Promise<string[]> {
+export interface ScanResult {
+  files: string[];
+  skippedCount: number;
+}
+
+export async function findAllSrtFiles(config: ScanConfig): Promise<ScanResult> {
   const engines = process.env.INCLUDE_ENGINES?.split(',') || ['ffsubsync', 'autosubsync', 'alass'];
   const files: string[] = [];
   let skippedCount = 0;
@@ -56,5 +61,5 @@ export async function findAllSrtFiles(config: ScanConfig): Promise<string[]> {
     console.log(`${new Date().toLocaleString()} Skipped ${skippedCount} already-synced SRT files`);
   }
 
-  return files;
+  return { files, skippedCount };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ async function main(): Promise<void> {
   try {
     // Find all .srt files
     const scanConfig = getScanConfig();
-    const srtFiles = await findAllSrtFiles(scanConfig);
-    console.log(`${new Date().toLocaleString()} Found ${srtFiles.length} SRT files`);
+    const { files: srtFiles, skippedCount } = await findAllSrtFiles(scanConfig);
+    console.log(`${new Date().toLocaleString()} Found ${srtFiles.length} SRT files (${skippedCount} already synced)`);
 
     const maxConcurrentSyncTasks = process.env.MAX_CONCURRENT_SYNC_TASKS
       ? parseInt(process.env.MAX_CONCURRENT_SYNC_TASKS)

--- a/src/processingEngine.ts
+++ b/src/processingEngine.ts
@@ -47,10 +47,10 @@ export class ProcessingEngine extends EventEmitter {
     this.log(`[${new Date().toISOString()}] Scanning for subtitle files...`);
     this.log(`[${new Date().toISOString()}] Scan paths: ${JSON.stringify(scanConfig.includePaths)}`);
 
-    const srtFiles = await findAllSrtFiles(scanConfig);
-    this.log(`[${new Date().toISOString()}] Found ${srtFiles.length} subtitle files`);
+    const { files: srtFiles, skippedCount } = await findAllSrtFiles(scanConfig);
+    this.log(`[${new Date().toISOString()}] Found ${srtFiles.length} subtitle files to process (${skippedCount} already synced)`);
 
-    this.emit('run:files_found', srtFiles);
+    this.emit('run:files_found', srtFiles, skippedCount);
 
     // Process in batches
     this.log(`[${new Date().toISOString()}] Processing with concurrency: ${this.maxConcurrent}`);

--- a/src/stateManager.ts
+++ b/src/stateManager.ts
@@ -36,13 +36,13 @@ export class StateManager extends EventEmitter {
   }
 
   // Run management
-  startRun(totalFiles: number, enabledEngines: string[] = ['ffsubsync', 'autosubsync', 'alass']): string {
+  startRun(totalFiles: number, enabledEngines: string[] = ['ffsubsync', 'autosubsync', 'alass'], alreadySyncedCount: number = 0): string {
     const runId = randomUUID();
     this.db.createRun(runId, totalFiles);
 
     // Set the total number of engines that will run (total_files * enabled_engines)
     const totalEngines = totalFiles * enabledEngines.length;
-    this.db.updateRun(runId, { total_engines: totalEngines });
+    this.db.updateRun(runId, { total_engines: totalEngines, skipped: alreadySyncedCount });
 
     this.currentRunId = runId;
 


### PR DESCRIPTION
Fixes #48

When a scan finds 0 unprocessed files (because everything is already synced), the app previously threw "Process completed without starting a run" which looked like an error.

Now it creates a run with `total_files=0` and `skipped=N` showing how many files were already synced. The run completes immediately and shows up in history with the skipped count, so users can see the scan worked — there was just nothing to do.