### PR TITLE
feat: add SYNC_LANGUAGES env var to filter by language

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ docker run -d \
 | --------------------------- | ----------------------------- | -------------------------------------------------------------------------------- |
 | `SCAN_PATHS`                | `/scan_dir`                   | Comma-separated directories to scan for SRT files (must be mounted as volumes)   |
 | `EXCLUDE_PATHS`             | _(none)_                      | Comma-separated directories to exclude from scanning                             |
+| `SYNC_LANGUAGES`            | _(none)_                      | Comma-separated language codes to sync (e.g., `en,de`). Only syncs subtitles with matching language tags in the filename (e.g., `movie.en.srt`). If not set, all subtitles are synced. |
 | `CRON_SCHEDULE`             | `0 0 * * *`                   | Cron expression for sync schedule (daily at midnight), or `disabled` to turn off |
 | `MAX_CONCURRENT_SYNC_TASKS` | `1`                           | Number of subtitle files to process in parallel (higher = faster but more CPU)   |
 | `INCLUDE_ENGINES`           | `ffsubsync,autosubsync,alass` | Which sync engines to use (comma-separated)                                      |

--- a/src/findAllSrtFiles.ts
+++ b/src/findAllSrtFiles.ts
@@ -13,6 +13,17 @@ function isAlreadySynced(srtPath: string, engines: string[]): boolean {
   });
 }
 
+function matchesLanguageFilter(fileName: string, languages: string[]): boolean {
+  if (languages.length === 0) return true;
+
+  // Extract language tag from filename like "movie.en.srt" or "movie.eng.srt"
+  const parts = basename(fileName, '.srt').split('.');
+  if (parts.length < 2) return false;
+
+  const langTag = parts[parts.length - 1].toLowerCase();
+  return languages.some((lang) => lang.toLowerCase() === langTag);
+}
+
 export interface ScanResult {
   files: string[];
   skippedCount: number;
@@ -20,8 +31,13 @@ export interface ScanResult {
 
 export async function findAllSrtFiles(config: ScanConfig): Promise<ScanResult> {
   const engines = process.env.INCLUDE_ENGINES?.split(',') || ['ffsubsync', 'autosubsync', 'alass'];
+  const languages = process.env.SYNC_LANGUAGES?.split(',').map((l) => l.trim()).filter(Boolean) || [];
   const files: string[] = [];
   let skippedCount = 0;
+
+  if (languages.length > 0) {
+    console.log(`${new Date().toLocaleString()} Language filter active: ${languages.join(', ')}`);
+  }
 
   async function scan(directory: string): Promise<void> {
     // Check if this directory should be excluded
@@ -41,7 +57,8 @@ export async function findAllSrtFiles(config: ScanConfig): Promise<ScanResult> {
         extname(entry.name).toLowerCase() === '.srt' &&
         !entry.name.includes('.ffsubsync.') &&
         !entry.name.includes('.alass.') &&
-        !entry.name.includes('.autosubsync.')
+        !entry.name.includes('.autosubsync.') &&
+        matchesLanguageFilter(entry.name, languages)
       ) {
         if (isAlreadySynced(fullPath, engines)) {
           skippedCount++;


### PR DESCRIPTION
Fixes #20

Adds `SYNC_LANGUAGES` env var (e.g., `en,de,fr`) to only sync subtitles with matching language tags in the filename. Files like `movie.en.srt` or `show.S01E01.eng.srt` are matched by the last dot-separated segment before `.srt`.

If not set, all subtitles are synced (no behavior change for existing users).