### PR TITLE
feat: folder picker UI for "Scan Specific Path" modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ testlogs
 data/logs/
 *.db-shm
 *.db-wal
+
+# JetBrains IDE
+.idea/
+
+# Claude Code local overrides
+CLAUDE.local.md
+.claude/CLAUDE.local.md

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,7 @@ class SubsyncarrPlusClient {
     this.state = { currentRun: null, files: [], isRunning: false };
     this.reconnectInterval = 3000;
     this.historyCache = {}; // Cache run data for file lookups
+    this.selectedPaths = [];
 
     this.initWebSocket();
     this.setupEventHandlers();
@@ -202,8 +203,7 @@ class SubsyncarrPlusClient {
     });
 
     document.getElementById('startCustom').addEventListener('click', () => {
-      document.getElementById('customPathModal').classList.remove('hidden');
-      document.getElementById('customPaths').value = ''; // Clear previous input
+      this.openPicker();
     });
 
     document.getElementById('stopRun').addEventListener('click', () => {
@@ -211,33 +211,27 @@ class SubsyncarrPlusClient {
     });
 
     document.getElementById('closeModal').addEventListener('click', () => {
-      console.log('Close button clicked');
-      document.getElementById('customPathModal').classList.add('hidden');
-      document.getElementById('customPaths').value = '';
+      this.closePicker();
     });
 
     document.getElementById('cancelCustom').addEventListener('click', () => {
-      document.getElementById('customPathModal').classList.add('hidden');
-      document.getElementById('customPaths').value = '';
+      this.closePicker();
     });
 
     document.getElementById('submitCustom').addEventListener('click', () => {
-      const paths = document
-        .getElementById('customPaths')
-        .value.split('\n')
-        .map((p) => p.trim())
-        .filter((p) => p.length > 0);
-
-      document.getElementById('customPathModal').classList.add('hidden');
-      document.getElementById('customPaths').value = '';
+      if (this.selectedPaths.length === 0) {
+        alert('Add at least one path before starting a scan.');
+        return;
+      }
+      const paths = this.selectedPaths.slice();
+      this.closePicker();
       this.startRun(paths);
     });
 
     // Close modal when clicking outside
     document.getElementById('customPathModal').addEventListener('click', (e) => {
       if (e.target.id === 'customPathModal') {
-        document.getElementById('customPathModal').classList.add('hidden');
-        document.getElementById('customPaths').value = '';
+        this.closePicker();
       }
     });
 
@@ -312,6 +306,173 @@ class SubsyncarrPlusClient {
         document.getElementById('fileListModal').classList.add('hidden');
       }
     });
+  }
+
+  async openPicker() {
+    this.selectedPaths = [];
+    this.renderSelectedPaths();
+    const tree = document.getElementById('folderTree');
+    tree.innerHTML = '<div class="tree-loading">Loading…</div>';
+    document.getElementById('customPathModal').classList.remove('hidden');
+    try {
+      const data = await this.fetchBrowse(null);
+      tree.innerHTML = '';
+      if (data.entries.length === 0) {
+        tree.innerHTML = '<div class="tree-empty">No paths configured. Set SCAN_PATHS env var.</div>';
+        return;
+      }
+      data.entries.forEach((entry) => tree.appendChild(this.makeTreeRow(entry, 0)));
+    } catch (err) {
+      tree.innerHTML = `<div class="tree-error">Failed to load: ${this.escapeHtml(err.message)}</div>`;
+    }
+  }
+
+  closePicker() {
+    document.getElementById('customPathModal').classList.add('hidden');
+  }
+
+  async fetchBrowse(path) {
+    const url = path ? `/api/browse?path=${encodeURIComponent(path)}` : '/api/browse';
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    return data;
+  }
+
+  makeTreeRow(entry, depth) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'tree-node';
+
+    const isFile = entry.isDir === false;
+
+    const row = document.createElement('div');
+    row.className = isFile ? 'tree-row tree-row-file' : 'tree-row';
+    row.style.paddingLeft = `${depth * 16}px`;
+
+    const chevron = document.createElement('span');
+    chevron.className = 'tree-chevron';
+    chevron.textContent = isFile ? '' : '▶';
+
+    const icon = document.createElement('span');
+    icon.className = 'tree-icon';
+    icon.textContent = isFile ? '📄' : '📁';
+
+    const name = document.createElement('span');
+    name.className = 'tree-name';
+    name.textContent = entry.name;
+    name.title = entry.path;
+
+    row.appendChild(chevron);
+    row.appendChild(icon);
+    row.appendChild(name);
+
+    if (isFile) {
+      // Files are display-only — no expand, no add.
+      wrapper.appendChild(row);
+      return wrapper;
+    }
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'tree-add';
+    addBtn.textContent = '+';
+    addBtn.title = 'Add this path';
+    addBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.addSelectedPath(entry.path);
+    });
+    row.appendChild(addBtn);
+
+    const children = document.createElement('div');
+    children.className = 'tree-children hidden';
+    let loaded = false;
+
+    const toggle = async () => {
+      if (!loaded) {
+        loaded = true;
+        children.innerHTML = '<div class="tree-loading" style="padding-left:' + (depth + 1) * 16 + 'px">Loading…</div>';
+        children.classList.remove('hidden');
+        chevron.textContent = '▼';
+        try {
+          const data = await this.fetchBrowse(entry.path);
+          children.innerHTML = '';
+          if (data.entries.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'tree-empty';
+            empty.style.paddingLeft = `${(depth + 1) * 16}px`;
+            empty.textContent = '(empty)';
+            children.appendChild(empty);
+          } else {
+            data.entries.forEach((child) => children.appendChild(this.makeTreeRow(child, depth + 1)));
+          }
+        } catch (err) {
+          children.innerHTML = '';
+          const errEl = document.createElement('div');
+          errEl.className = 'tree-error';
+          errEl.style.paddingLeft = `${(depth + 1) * 16}px`;
+          errEl.textContent = `Failed to load: ${err.message}`;
+          children.appendChild(errEl);
+        }
+        return;
+      }
+      const willOpen = children.classList.contains('hidden');
+      children.classList.toggle('hidden');
+      chevron.textContent = willOpen ? '▼' : '▶';
+    };
+
+    chevron.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggle();
+    });
+    name.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggle();
+    });
+
+    wrapper.appendChild(row);
+    wrapper.appendChild(children);
+    return wrapper;
+  }
+
+  addSelectedPath(path) {
+    if (this.selectedPaths.includes(path)) return;
+    this.selectedPaths.push(path);
+    this.renderSelectedPaths();
+  }
+
+  removeSelectedPath(path) {
+    this.selectedPaths = this.selectedPaths.filter((p) => p !== path);
+    this.renderSelectedPaths();
+  }
+
+  renderSelectedPaths() {
+    const list = document.getElementById('selectedPaths');
+    const empty = document.getElementById('selectedPathsEmpty');
+    list.innerHTML = '';
+    if (this.selectedPaths.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+    empty.classList.add('hidden');
+    this.selectedPaths.forEach((path) => {
+      const li = document.createElement('li');
+      li.dataset.fullpath = path;
+      li.title = path;
+      const span = document.createElement('span');
+      span.className = 'selected-path-text';
+      span.textContent = path;
+      const btn = document.createElement('button');
+      btn.className = 'selected-path-remove';
+      btn.textContent = '×';
+      btn.title = 'Remove';
+      btn.addEventListener('click', () => this.removeSelectedPath(path));
+      li.appendChild(span);
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  }
+
+  escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
   }
 
   async startRun(paths = null) {

--- a/public/index.html
+++ b/public/index.html
@@ -103,12 +103,19 @@
     </div>
 
     <div id="customPathModal" class="modal hidden">
-      <div class="modal-content">
+      <div class="modal-content picker-modal">
         <div class="modal-header">
           <h3>Scan Specific Paths</h3>
           <button id="closeModal" class="btn-close">&times;</button>
         </div>
-        <textarea id="customPaths" placeholder="/path/to/directory1&#10;/path/to/directory2"></textarea>
+        <div class="picker-body">
+          <div class="picker-tree" id="folderTree"></div>
+          <div class="picker-selected">
+            <div class="picker-selected-header">Selected Paths</div>
+            <ul id="selectedPaths" class="selected-paths"></ul>
+            <div id="selectedPathsEmpty" class="picker-empty">Click <strong>+</strong> next to a folder to add it.</div>
+          </div>
+        </div>
         <div class="modal-actions">
           <button id="cancelCustom" class="btn btn-secondary">Cancel</button>
           <button id="submitCustom" class="btn btn-primary">Start Scan</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -430,16 +430,205 @@ td {
   color: var(--text);
 }
 
-#customPaths {
-  width: 100%;
-  min-height: 120px;
-  padding: 12px;
+/* Folder picker modal */
+.modal-content.picker-modal {
+  max-width: 760px;
+  width: 90%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.picker-body {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+  min-height: 320px;
+  max-height: 55vh;
+  margin-bottom: 16px;
+}
+
+.picker-tree {
+  flex: 1.4;
+  overflow: auto;
   border: 1px solid var(--border);
   border-radius: 6px;
-  font-family: monospace;
+  padding: 8px;
+  background: var(--background);
   font-size: 14px;
-  margin-bottom: 16px;
-  resize: vertical;
+}
+
+.picker-selected {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.picker-selected-header {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.picker-empty {
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 12px;
+  background: var(--background);
+  border-radius: 6px;
+  text-align: center;
+}
+
+.tree-node {
+  user-select: none;
+}
+
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 4px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tree-row:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.tree-chevron {
+  display: inline-block;
+  width: 12px;
+  font-size: 10px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.tree-icon {
+  display: inline-block;
+  width: 16px;
+  font-size: 12px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.tree-name {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tree-row-file {
+  cursor: default;
+}
+
+.tree-row-file:hover {
+  background: transparent;
+}
+
+.tree-row-file .tree-name {
+  color: var(--text-secondary);
+}
+
+.tree-add {
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.tree-row:hover .tree-add {
+  opacity: 1;
+}
+
+.tree-add:hover {
+  background: var(--primary-dark);
+}
+
+.tree-loading,
+.tree-empty,
+.tree-error {
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 4px;
+}
+
+.tree-error {
+  color: var(--error);
+}
+
+.selected-paths {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow: auto;
+  flex: 1;
+}
+
+.selected-paths li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--background);
+  border-radius: 4px;
+  margin-bottom: 6px;
+  font-size: 13px;
+  position: relative;
+}
+
+.selected-path-text {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+  min-width: 0;
+}
+
+/* On hover, expand the chip inline to show the full path. Avoids a
+   floating tooltip getting clipped by the parent's overflow:auto. */
+.selected-paths li:hover .selected-path-text {
+  white-space: normal;
+  word-break: break-all;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.selected-paths li:hover {
+  background: var(--border);
+}
+
+.selected-path-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+.selected-path-remove:hover {
+  background: var(--error);
+  color: white;
 }
 
 .modal-actions {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,8 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createServer } from 'http';
 import { ProcessingCoordinator } from './coordinator';
 import { StateManager } from './stateManager';
-import { join } from 'path';
+import { join, resolve as resolvePath } from 'path';
+import * as fs from 'fs';
 import { getScanConfig } from './config';
 import cronstrue from 'cronstrue';
 import parseExpression from 'cron-parser';
@@ -62,6 +63,66 @@ export class SubsyncarrPlusServer {
           nextRun: nextRun,
         },
       });
+    });
+
+    // Browse directories within the configured SCAN_PATHS.
+    // No `path` query → returns the configured roots as virtual top-level entries.
+    // Otherwise enumerates immediate subdirectories of `path`, but only if `path`
+    // resolves inside one of the configured roots.
+    this.app.get('/api/browse', (req, res) => {
+      const requestedPath = typeof req.query.path === 'string' ? req.query.path : '';
+      console.log(`[${new Date().toISOString()}] GET /api/browse${requestedPath ? ` path=${requestedPath}` : ''}`);
+
+      const roots = getScanConfig().includePaths;
+
+      if (!requestedPath) {
+        const entries = roots.map((p) => ({ name: p, path: p, isRoot: true }));
+        return res.json({ path: null, entries });
+      }
+
+      // Normalize the requested path lexically (strip trailing slash, resolve `.`/`..`)
+      // without following symlinks — this is what we return so paths shown to the user
+      // match what they clicked. We separately follow symlinks for the security check.
+      const normalizedRequest = resolvePath(requestedPath);
+
+      let resolvedPath: string;
+      try {
+        resolvedPath = fs.realpathSync(normalizedRequest);
+      } catch (err: unknown) {
+        const code = (err as { code?: string }).code;
+        if (code === 'ENOENT') return res.status(404).json({ error: 'path does not exist' });
+        if (code === 'EACCES') return res.status(403).json({ error: 'permission denied' });
+        return res.status(500).json({ error: (err as Error).message });
+      }
+
+      const isAllowed = roots.some((root) => {
+        let r: string;
+        try {
+          r = fs.realpathSync(resolvePath(root));
+        } catch {
+          return false;
+        }
+        return resolvedPath === r || resolvedPath.startsWith(r + '/');
+      });
+      if (!isAllowed) {
+        return res.status(403).json({ error: 'path outside SCAN_PATHS' });
+      }
+
+      try {
+        const entries = fs
+          .readdirSync(resolvedPath, { withFileTypes: true })
+          .filter((d) => !d.name.startsWith('.') && (d.isDirectory() || d.isFile()))
+          .map((d) => ({ name: d.name, path: join(normalizedRequest, d.name), isDir: d.isDirectory() }))
+          .sort((a, b) => {
+            if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+            return a.name.localeCompare(b.name);
+          });
+        return res.json({ path: normalizedRequest, entries });
+      } catch (err: unknown) {
+        const code = (err as { code?: string }).code;
+        if (code === 'EACCES') return res.status(403).json({ error: 'permission denied' });
+        return res.status(500).json({ error: (err as Error).message });
+      }
     });
 
     // Get current status


### PR DESCRIPTION
## Why

Typing absolute container paths into a textarea is annoying. If I have to hand-construct `/movies/Action/2024` somewhere else first, I might as well skip the UI and call the CLI. The modal needed to be something worth using.

## What changed

Replaces the textarea in the **Scan Specific Paths** modal with a clickable folder picker. Backend adds a single `GET /api/browse` endpoint, scoped to the configured `SCAN_PATHS`.

### Before
<img width="1280" height="900" alt="before-02-modal" src="https://github.com/user-attachments/assets/cdbb59a0-ec74-4508-ae8d-e356590096bd" />

### After

Opening the modal lists the configured `SCAN_PATHS` as collapsed roots.
<img width="1280" height="900" alt="after-01-modal-empty" src="https://github.com/user-attachments/assets/6de121da-b4cc-4921-8f5b-184ea99290e6" />

Expanding a folder lazy-loads its children. Folders show a chevron, folder icon, and an `Add` button on hover. Files appear for context as display-only rows (file icon, dimmed, no `+`) — the sync engine still only operates on directories, but seeing what's inside helps confirm you're picking the right folder.
<img width="1280" height="900" alt="after-02-modal-expanded" src="https://github.com/user-attachments/assets/d3ace1fc-6dac-40ed-989c-3efe864110e1" />

`+` pushes the folder into the chip list. `×` removes it.
<img width="1280" height="900" alt="after-03-modal-selected" src="https://github.com/user-attachments/assets/fc67d722-c1b3-407c-98eb-068a2b83e225" />

Works across multiple watched roots — one pick from each:
<img width="1280" height="900" alt="after-05-multi-root" src="https://github.com/user-attachments/assets/ebc31628-76b3-456d-a833-3d86d218d38d" />

Long paths get truncated with `…`. Hovering a chip expands it inline to show the full path:
<img width="1280" height="900" alt="after-06-hover-tooltip" src="https://github.com/user-attachments/assets/8bc02da4-6bca-44d1-aec8-94e95a28dbc0" />

## Design decisions

- **Backend scoped to `SCAN_PATHS`, not the whole filesystem.** `GET /api/browse` resolves both the requested path and the configured roots through `realpath`, and rejects anything that isn't a descendant of one of those roots. The operator already trusts `SCAN_PATHS` — reusing it as the picker's scope avoided shipping a general-purpose filesystem-listing endpoint that could leak directory structure if the container were ever exposed. Also keeps the feature useful even when `CRON_SCHEDULE=disabled` — the watched folders alone drive the picker.

- **No third-party library.** The dominant vanilla-JS tree widget (`jsTree`) requires jQuery, and this project has zero frontend dependencies and no build step. Adding two CDN scripts (jQuery + jsTree) for one modal wasn't worth it. The picker is ~120 LOC of vanilla JS in `public/app.js`, written in the same style as the rest of the file.

- **Files shown but not selectable.** Initial pass listed only directories, which made it hard to tell if a folder was the right one to add. Showing files as display-only rows gives the same context Finder/Explorer does, without changing what the sync engine operates on.

- **Inline chip expansion on hover.** Native `title` tooltips have a ~1s delay. A floating CSS tooltip kept getting clipped by the chip list's `overflow: auto`. Expanding the chip text inline on `:hover` avoids the clip entirely and feels more direct.

- **Request path preserved in the response.** `realpath` is used internally for the security check, but the endpoint returns the path as the user supplied it. So a click on `/tmp/subsyncarr/tree-picker` shows up in the chip list as `/tmp/...`, not `/private/tmp/...` (macOS `/tmp` symlink). Operationally invisible in Docker, just less surprising during local dev.

## AI disclosure

Built with Claude Code; this PR description was also drafted with Claude. I didn't see anything in the contribution guidelines against AI-assisted contributions — happy to discuss if that's not the case. The feature commit has a `Co-Authored-By` trailer making the tool use explicit. I designed the changes (scope, library choice, UX behavior); the AI executed against my direction. I stand behind every line.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>