### PR TITLE
feat: customizable suffix for synced subtitle filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ docker run -d \
 | `CRON_SCHEDULE`             | `0 0 * * *`                   | Cron expression for sync schedule (daily at midnight), or `disabled` to turn off |
 | `MAX_CONCURRENT_SYNC_TASKS` | `1`                           | Number of subtitle files to process in parallel (higher = faster but more CPU)   |
 | `INCLUDE_ENGINES`           | `ffsubsync,autosubsync,alass` | Which sync engines to use (comma-separated)                                      |
+| `FFSUBSYNC_SUFFIX`          | `ffsubsync`                   | Custom suffix for ffsubsync output files (e.g., `sdh` → `movie.en.sdh.srt`)     |
+| `AUTOSUBSYNC_SUFFIX`        | `autosubsync`                 | Custom suffix for autosubsync output files (e.g., `cc` → `movie.en.cc.srt`)     |
+| `ALASS_SUFFIX`              | `alass`                       | Custom suffix for alass output files (e.g., `forced` → `movie.en.forced.srt`)   |
 | `SYNC_TIMEOUT`              | _(none)_                      | Timeout in seconds per sync operation (overrides SYNC_ENGINE_TIMEOUT_MS)         |
 | `SYNC_ENGINE_TIMEOUT_MS`    | `1800000`                     | Timeout for each sync engine in milliseconds (30 min default)                    |
 | `NODE_OPTIONS`             | `--max-old-space-size=512`    | Node.js options, used here to set memory limit (in MB)                           |

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,20 @@ export interface ScanConfig {
   excludePaths: string[];
 }
 
+export interface SuffixConfig {
+  ffsubsync: string;
+  autosubsync: string;
+  alass: string;
+}
+
+export function getSuffixConfig(): SuffixConfig {
+  return {
+    ffsubsync: process.env.FFSUBSYNC_SUFFIX || 'ffsubsync',
+    autosubsync: process.env.AUTOSUBSYNC_SUFFIX || 'autosubsync',
+    alass: process.env.ALASS_SUFFIX || 'alass',
+  };
+}
+
 export interface RetentionConfig {
   keepRunsDays: number; // Keep complete runs for N days
   trimLogsDays: number; // Trim logs after N days

--- a/src/findAllSrtFiles.ts
+++ b/src/findAllSrtFiles.ts
@@ -1,14 +1,15 @@
 import { readdir } from 'fs/promises';
-import { basename, dirname, extname, join } from 'path';
+import { basename, extname, join } from 'path';
 import { existsSync } from 'fs';
-import { ScanConfig } from './config';
+import { getSuffixConfig, ScanConfig } from './config';
+import { buildOutputPath } from './helpers';
 
 function isAlreadySynced(srtPath: string, engines: string[]): boolean {
-  const directory = dirname(srtPath);
-  const srtBaseName = basename(srtPath, '.srt');
+  const suffixConfig = getSuffixConfig();
 
   return engines.every((engine) => {
-    const outputPath = join(directory, `${srtBaseName}.${engine}.srt`);
+    const suffix = suffixConfig[engine as keyof typeof suffixConfig] || engine;
+    const outputPath = buildOutputPath(srtPath, suffix);
     return existsSync(outputPath);
   });
 }
@@ -39,6 +40,11 @@ export async function findAllSrtFiles(config: ScanConfig): Promise<ScanResult> {
     console.log(`${new Date().toLocaleString()} Language filter active: ${languages.join(', ')}`);
   }
 
+  const suffixConfig = getSuffixConfig();
+  const syncedSuffixes = engines.map(
+    (engine) => `.${suffixConfig[engine as keyof typeof suffixConfig] || engine}.`,
+  );
+
   async function scan(directory: string): Promise<void> {
     // Check if this directory should be excluded
     if (config.excludePaths.some((excludePath) => directory.startsWith(excludePath))) {
@@ -55,9 +61,7 @@ export async function findAllSrtFiles(config: ScanConfig): Promise<ScanResult> {
       } else if (
         entry.isFile() &&
         extname(entry.name).toLowerCase() === '.srt' &&
-        !entry.name.includes('.ffsubsync.') &&
-        !entry.name.includes('.alass.') &&
-        !entry.name.includes('.autosubsync.') &&
+        !syncedSuffixes.some((suffix) => entry.name.includes(suffix)) &&
         matchesLanguageFilter(entry.name, languages)
       ) {
         if (isAlreadySynced(fullPath, engines)) {

--- a/src/generateAlassSubtitles.ts
+++ b/src/generateAlassSubtitles.ts
@@ -1,11 +1,9 @@
-import { basename, dirname, join } from 'path';
-import { execPromise, ProcessingResult } from './helpers';
+import { buildOutputPath, execPromise, ProcessingResult } from './helpers';
 import { existsSync } from 'fs';
+import { getSuffixConfig } from './config';
 
 export async function generateAlassSubtitles(srtPath: string, videoPath: string): Promise<ProcessingResult> {
-  const directory = dirname(srtPath);
-  const srtBaseName = basename(srtPath, '.srt');
-  const outputPath = join(directory, `${srtBaseName}.alass.srt`);
+  const outputPath = buildOutputPath(srtPath, getSuffixConfig().alass);
 
   const exists = existsSync(outputPath);
   if (exists) {

--- a/src/generateAutosubsyncSubtitles.ts
+++ b/src/generateAutosubsyncSubtitles.ts
@@ -1,11 +1,9 @@
-import { basename, dirname, join } from 'path';
-import { execPromise, ProcessingResult } from './helpers';
+import { buildOutputPath, execPromise, ProcessingResult } from './helpers';
 import { existsSync } from 'fs';
+import { getSuffixConfig } from './config';
 
 export async function generateAutosubsyncSubtitles(srtPath: string, videoPath: string): Promise<ProcessingResult> {
-  const directory = dirname(srtPath);
-  const srtBaseName = basename(srtPath, '.srt');
-  const outputPath = join(directory, `${srtBaseName}.autosubsync.srt`);
+  const outputPath = buildOutputPath(srtPath, getSuffixConfig().autosubsync);
 
   const exists = existsSync(outputPath);
   if (exists) {

--- a/src/generateFfsubsyncSubtitles.ts
+++ b/src/generateFfsubsyncSubtitles.ts
@@ -1,11 +1,9 @@
-import { basename, dirname, join } from 'path';
-import { execPromise, ProcessingResult } from './helpers';
+import { buildOutputPath, execPromise, ProcessingResult } from './helpers';
 import { existsSync } from 'fs';
+import { getSuffixConfig } from './config';
 
 export async function generateFfsubsyncSubtitles(srtPath: string, videoPath: string): Promise<ProcessingResult> {
-  const directory = dirname(srtPath);
-  const srtBaseName = basename(srtPath, '.srt');
-  const outputPath = join(directory, `${srtBaseName}.ffsubsync.srt`);
+  const outputPath = buildOutputPath(srtPath, getSuffixConfig().ffsubsync);
 
   // Check if synced subtitle already exists
   const exists = existsSync(outputPath);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,14 @@
 import { exec } from 'child_process';
+import { basename, dirname, join } from 'path';
+
+export function buildOutputPath(srtPath: string, suffix: string): string {
+  const directory = dirname(srtPath);
+  let srtBaseName = basename(srtPath, '.srt');
+  if (srtBaseName.endsWith(`.${suffix}`)) {
+    srtBaseName = srtBaseName.slice(0, -(suffix.length + 1));
+  }
+  return join(directory, `${srtBaseName}.${suffix}.srt`);
+}
 
 export interface ProcessingResult {
   success: boolean;


### PR DESCRIPTION
## Summary
- Adds `FFSUBSYNC_SUFFIX`, `AUTOSUBSYNC_SUFFIX`, and `ALASS_SUFFIX` env vars to control the output filename suffix (defaults unchanged: `ffsubsync`, `autosubsync`, `alass`)
- Enables Bazarr compatibility by allowing suffixes like `cc`, `sdh`, or `forced` that Bazarr recognizes
- Handles duplicate suffix edge case (e.g., `movie.en.cc.srt` won't produce `movie.en.cc.cc.srt`)

Fixes #25

## Test plan
- [x] Set `FFSUBSYNC_SUFFIX=sdh` and verify output is `movie.en.sdh.srt`
- [x] Verify default behavior unchanged when env vars are not set
- [x] Test with source file that already has the custom suffix in its name (duplicate prevention)
- [x] Verify file scanner correctly skips already-synced files using custom suffixes