### PR TITLE
feat: show error messages for failed files in WebUI (fixes #59)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -647,11 +647,18 @@ class SubsyncarrPlusClient {
         const icon = result.success ? '✓' : '✗';
         const className = result.success ? 'success' : 'error';
         const duration = (result.duration / 1000).toFixed(1);
+        const error =
+          !result.success && result.message
+            ? `<div class="engine-error-message">${this.escapeHtml(result.message)}</div>`
+            : '';
 
         return `
         <div class="engine-result ${className}">
-          <span>${icon} ${name}</span>
-          <span class="duration">${duration}s</span>
+          <div class="engine-result-row">
+            <span>${icon} ${name}</span>
+            <span class="duration">${duration}s</span>
+          </div>
+          ${error}
         </div>
       `;
       })
@@ -813,12 +820,44 @@ class SubsyncarrPlusClient {
         '<div class="file-list-empty">No files in this category</div>';
     } else {
       const html = files
-        .map((file) => `<div class="file-list-item">${this.cleanFileName(file.file_path)}</div>`)
+        .map((file) => {
+          const name = this.cleanFileName(file.file_path);
+          const errors = category === 'failed' ? this.renderFileErrors(file) : '';
+          return `<div class="file-list-item">${this.escapeHtml(name)}${errors}</div>`;
+        })
         .join('');
       document.getElementById('fileListContent').innerHTML = html;
     }
 
     document.getElementById('fileListModal').classList.remove('hidden');
+  }
+
+  // Render the error messages for each engine that failed on a file
+  renderFileErrors(file) {
+    let engines;
+    try {
+      engines = JSON.parse(file.engines || '{}');
+    } catch {
+      return '';
+    }
+
+    const failures = Object.entries(engines).filter(([, result]) => result && result.success === false);
+
+    if (failures.length === 0) {
+      return '';
+    }
+
+    return `<div class="file-list-errors">${failures
+      .map(([name, result]) => {
+        const message = result.message || 'Unknown error';
+        const stderr = result.stderr ? `<pre class="file-error-detail">${this.escapeHtml(result.stderr)}</pre>` : '';
+        return `<div class="file-error">
+          <span class="file-error-engine">${this.escapeHtml(name)}</span>
+          <span class="file-error-message">${this.escapeHtml(message)}</span>
+          ${stderr}
+        </div>`;
+      })
+      .join('')}</div>`;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -319,6 +319,24 @@ h2 {
 .engine-result.error {
   background: #fee2e2;
   color: #991b1b;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.engine-result-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.engine-error-message {
+  margin-top: 4px;
+  font-size: 12px;
+  font-family: var(--mono, ui-monospace, monospace);
+  white-space: pre-wrap;
+  word-break: break-word;
+  opacity: 0.9;
 }
 
 .duration {
@@ -775,6 +793,47 @@ td {
   text-align: center;
   padding: 20px;
   font-style: italic;
+}
+
+.file-list-errors {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.file-error {
+  border-left: 3px solid var(--error);
+  padding: 4px 0 4px 10px;
+}
+
+.file-error-engine {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--error);
+  margin-right: 8px;
+}
+
+.file-error-message {
+  font-size: 13px;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.file-error-detail {
+  margin: 6px 0 0;
+  padding: 8px;
+  background: var(--background);
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 160px;
+  overflow-y: auto;
+  color: var(--text-secondary);
 }
 
 /* Mobile responsive */


### PR DESCRIPTION
## Summary

Fixes #59. The **Failed** files list in the WebUI previously showed only filenames — to find out *why* a file failed, you had to dig through the logs and search for the filename by hand. This surfaces the per-engine error messages directly in the modal.

The error data was already being captured and persisted in the `engines` JSON column and returned by the API — the frontend was just discarding it. So this is a frontend-only change: no DB migration, no API changes.

## What changed

- **`public/app.js`**
  - `showFileList()` now renders the error messages for each failed engine beneath the filename (new `renderFileErrors()` helper). Engine `stderr` is shown in a collapsible-style `<pre>` block when present.
  - `renderEngineResults()` (live/in-progress view) now displays `result.message` on failed engines instead of just the ✗ icon.
  - Filenames are now run through `escapeHtml()` (they weren't before).
- **`public/styles.css`** — styling for the error blocks (red accent bar, engine label, monospace stderr detail).

## Screenshot

Real Subsyncarr+ UI — clicking the **Failed** count opens the modal with error messages inline:

![Failed files modal with error messages](https://files.jpc.io/d/YvCwo-real-failed-modal.png)

## Notes

- Verified by running the actual server-rendered `public/` UI (real `app.js` + `index.html` + `styles.css`) against a seeded failed run and clicking the real **Failed** count — the screenshot above is that modal, not a mockup.
- One pre-existing behavior worth flagging (out of scope here): a file only counts as `failed` when *every* engine fails. A file where one engine fails but another succeeds is marked `completed`, so partial failures still won't appear in this list.
